### PR TITLE
fix parsing /proc/net/dev on Linux

### DIFF
--- a/network/network_linux.go
+++ b/network/network_linux.go
@@ -32,20 +32,24 @@ func collectNetworkStats(out io.Reader) ([]Stats, error) {
 	scanner := bufio.NewScanner(out)
 	var networks []Stats
 	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
 		// Reference: dev_seq_printf_stats in Linux source code
-		if len(fields) < 17 || len(fields) > 0 && !strings.HasSuffix(fields[0], ":") {
+		kv := strings.SplitN(scanner.Text(), ":", 2)
+		if len(kv) != 2 {
 			continue
 		}
-		name := fields[0][:len(fields[0])-1]
+		fields := strings.Fields(kv[1])
+		if len(fields) < 16 {
+			continue
+		}
+		name := strings.TrimSpace(kv[0])
 		if name == "lo" {
 			continue
 		}
-		rxBytes, err := strconv.ParseUint(fields[1], 10, 64)
+		rxBytes, err := strconv.ParseUint(fields[0], 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse rxBytes of %s", name)
 		}
-		txBytes, err := strconv.ParseUint(fields[9], 10, 64)
+		txBytes, err := strconv.ParseUint(fields[8], 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse txBytes of %s", name)
 		}

--- a/network/network_linux_test.go
+++ b/network/network_linux_test.go
@@ -28,6 +28,7 @@ func TestCollectNetworkStats(t *testing.T) {
  wlan0: 1188035151  850857    0    0    0     0          0         0 49774221  428282    0    0    0     0       0          0
     lo: 1292817    9913    0    0    0     0          0         0  1292817    9913    0    0    0     0       0          0
   eth0: 26054426   73542    0    0    0     0          0         0 12352148   58473    0    0    0     0       0          0
+  eth1:183651236    3482    0    0    0     0          0         0 93127469    1924    0    0    0     0       0          0
 `))
 	if err != nil {
 		t.Fatalf("error should be nil but got: %v", err)
@@ -35,6 +36,7 @@ func TestCollectNetworkStats(t *testing.T) {
 	expected := []Stats{
 		{"wlan0", 1188035151, 49774221},
 		{"eth0", 26054426, 12352148},
+		{"eth1", 183651236, 93127469},
 	}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("invalid network value: %+v (expected: %+v)", got, expected)


### PR DESCRIPTION
This pull request fixes a problem of network statistics on Linux. We cannot assume a space after the interface name.