### PR TITLE
Fix crash on empty line in /proc/stat

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -74,7 +74,7 @@ func collectCPUStats(out io.Reader) (*Stats, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if line[0] == 'c' && line[1] == 'p' && line[2] == 'u' && unicode.IsDigit(rune(line[3])) {
+		if line != "" && line[0] == 'c' && line[1] == 'p' && line[2] == 'u' && unicode.IsDigit(rune(line[3])) {
 			cpu.CPUCount++
 		}
 	}


### PR DESCRIPTION
Sometimes /proc/stat contain one or more empty line.

```sh
$ cat /proc/version
Linux version 2.6.32-042stab092.2 (root@kbuild-rh6-x64) (gcc version 4.4.6 20120305 (Red Hat 4.4.6-4) (GCC) ) #1 SMP Tue Jul 8 10:35:55 MSK 2014
$ cat /etc/debian_version
7.11
$ cat /proc/stat
cpu  7470681 0 1586197 13118409351 150947 0 0 0
cpu0 3293762 0 733398 6560288846 63595 0 0 0
cpu1 4176919 0 852799 6558120504 87351 0 0 0
intr 0
swap 0 0

ctxt 93458773
btime 1447514956
processes 275160
procs_running 0
procs_blocked 0
```