### PR TITLE
[nit] Use Go 1.9.x on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.9
+  - 1.9.x
 
 script:
   - go version


### PR DESCRIPTION
Upgrade the Go version to the latest.