### PR TITLE
consider MemAvailable field in `/proc/meminfo` on linux

### DIFF
--- a/memory/memory_linux_test.go
+++ b/memory/memory_linux_test.go
@@ -23,7 +23,6 @@ func TestCollectMemoryStats(t *testing.T) {
 	got, err := collectMemoryStats(strings.NewReader(
 		`MemTotal:        1929620 kB
 MemFree:          113720 kB
-MemAvailable:     533132 kB
 Buffers:           81744 kB
 Cached:           435712 kB
 SwapCached:          504 kB
@@ -78,13 +77,85 @@ DirectMap2M:      888832 kB
 		Buffers:    uint64(81744 * 1024),
 		Cached:     uint64(435712 * 1024),
 		Free:       uint64(113720 * 1024),
-		Available:  uint64(533132 * 1024),
 		Active:     uint64(817412 * 1024),
 		Inactive:   uint64(754140 * 1024),
 		SwapTotal:  uint64(1959932 * 1024),
 		SwapUsed:   uint64(2432 * 1024),
 		SwapCached: uint64(504 * 1024),
 		SwapFree:   uint64(1957500 * 1024),
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("invalid memory value: %+v (expected: %+v)", got, expected)
+	}
+}
+
+func TestCollectMemoryStats_memAvailable(t *testing.T) {
+	got, err := collectMemoryStats(strings.NewReader(
+		`MemTotal:        1929620 kB
+MemFree:          113720 kB
+MemAvailable:     533132 kB
+Buffers:           81744 kB
+Cached:           435712 kB
+SwapCached:          504 kB
+Active:           817412 kB
+Inactive:         754140 kB
+Active(anon):     647484 kB
+Inactive(anon):   570160 kB
+Active(file):     169928 kB
+Inactive(file):   183980 kB
+Unevictable:         124 kB
+Mlocked:             124 kB
+HighTotal:       1047928 kB
+HighFree:          18692 kB
+LowTotal:         881692 kB
+LowFree:           95028 kB
+SwapTotal:       1959932 kB
+SwapFree:        1957500 kB
+Dirty:               352 kB
+Writeback:             0 kB
+AnonPages:       1053804 kB
+Mapped:           151408 kB
+Shmem:            163548 kB
+Slab:             202768 kB
+SReclaimable:     177128 kB
+SUnreclaim:        25640 kB
+KernelStack:        4624 kB
+PageTables:        15944 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     2924740 kB
+Committed_AS:    7238800 kB
+VmallocTotal:     122880 kB
+VmallocUsed:       16344 kB
+VmallocChunk:     102740 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:    145408 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:       24568 kB
+DirectMap2M:      888832 kB
+`))
+	if err != nil {
+		t.Fatalf("error should be nil but got: %v", err)
+	}
+	expected := &Stats{
+		Total:               uint64(1929620 * 1024),
+		Used:                uint64(1396488 * 1024),
+		Buffers:             uint64(81744 * 1024),
+		Cached:              uint64(435712 * 1024),
+		Free:                uint64(113720 * 1024),
+		Available:           uint64(533132 * 1024),
+		Active:              uint64(817412 * 1024),
+		Inactive:            uint64(754140 * 1024),
+		SwapTotal:           uint64(1959932 * 1024),
+		SwapUsed:            uint64(2432 * 1024),
+		SwapCached:          uint64(504 * 1024),
+		SwapFree:            uint64(1957500 * 1024),
+		MemAvailableEnabled: true,
 	}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("invalid memory value: %+v (expected: %+v)", got, expected)

--- a/memory/memory_linux_test.go
+++ b/memory/memory_linux_test.go
@@ -72,17 +72,18 @@ DirectMap2M:      888832 kB
 		t.Fatalf("error should be nil but got: %v", err)
 	}
 	expected := &Stats{
-		Total:      uint64(1929620 * 1024),
-		Used:       uint64(1298444 * 1024),
-		Buffers:    uint64(81744 * 1024),
-		Cached:     uint64(435712 * 1024),
-		Free:       uint64(113720 * 1024),
-		Active:     uint64(817412 * 1024),
-		Inactive:   uint64(754140 * 1024),
-		SwapTotal:  uint64(1959932 * 1024),
-		SwapUsed:   uint64(2432 * 1024),
-		SwapCached: uint64(504 * 1024),
-		SwapFree:   uint64(1957500 * 1024),
+		Total:               uint64(1929620 * 1024),
+		Used:                uint64(1298444 * 1024),
+		Buffers:             uint64(81744 * 1024),
+		Cached:              uint64(435712 * 1024),
+		Free:                uint64(113720 * 1024),
+		Active:              uint64(817412 * 1024),
+		Inactive:            uint64(754140 * 1024),
+		SwapTotal:           uint64(1959932 * 1024),
+		SwapUsed:            uint64(2432 * 1024),
+		SwapCached:          uint64(504 * 1024),
+		SwapFree:            uint64(1957500 * 1024),
+		MemAvailableEnabled: false,
 	}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("invalid memory value: %+v (expected: %+v)", got, expected)


### PR DESCRIPTION
When there is a `MemAvailable` field, which is enabled in linux kernel 3.19.1 or later in `/proc/meminfo`, we use it to calculate accurate memory usage.

If `MemAvailable` field is available, `MemAvailableEnabled` field turn true.

- Added `MemAvailableEnabled` field to determine if `MemAvaileble` can be acquired
- Adjust the `stats.Used` calculation way when the` MemAvailableEnabled` field is true
  - It does not affect `mackerel-agent` because which calculate `memory.used` by itself https://github.com/mackerelio/mackerel-agent/blob/9061847409f4f4f7eed550387c58873e86cde1fe/metrics/linux/memory.go#L38

ref. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773