### PR TITLE
use x/sys/unix instead of syscall for linux

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
-golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54 h1:xe1/2UUJRmA9iDglQSlkx8c5n3twv58+K0mPpC2zmhA=
-golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190410235845-0ad05ae3009d h1:+9jagSGtlJZAaZGdRvJikXNpc5lh2/rq9eyMN/5kmwA=
 golang.org/x/sys v0.0.0-20190410235845-0ad05ae3009d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/uptime/uptime_linux.go
+++ b/uptime/uptime_linux.go
@@ -3,13 +3,14 @@
 package uptime
 
 import (
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func get() (time.Duration, error) {
-	var info syscall.Sysinfo_t
-	if err := syscall.Sysinfo(&info); err != nil {
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
 		return time.Duration(0), err
 	}
 	return time.Duration(info.Uptime) * time.Second, nil


### PR DESCRIPTION
According to the Go official document (https://golang.org/pkg/syscall), the syscall package is deprecated and recommended to use x/sys packages instead.
Also updates the go.sum