### PR TITLE
collect the zombie process surely

### DIFF
--- a/memory/memory_darwin.go
+++ b/memory/memory_darwin.go
@@ -28,7 +28,7 @@ func Get() (*Stats, error) {
 	memory, err := collectMemoryStats(out)
 	if err != nil {
 		cmd.Process.Kill() // The process may stuck on write to pipe if the pipe buffer in kernel is full.
-		cmd.Wait()
+		go cmd.Wait()
 		return nil, err
 	}
 	if err := cmd.Wait(); err != nil {

--- a/memory/memory_darwin.go
+++ b/memory/memory_darwin.go
@@ -27,6 +27,8 @@ func Get() (*Stats, error) {
 	}
 	memory, err := collectMemoryStats(out)
 	if err != nil {
+		cmd.Process.Kill() // The process may stuck on write to pipe if the pipe buffer in kernel is full.
+		cmd.Wait()
 		return nil, err
 	}
 	if err := cmd.Wait(); err != nil {

--- a/memory/memory_darwin.go
+++ b/memory/memory_darwin.go
@@ -18,7 +18,7 @@ import (
 
 // Get memory statistics
 func Get() (*Stats, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Reference: man 1 vm_stat

--- a/memory/memory_freebsd.go
+++ b/memory/memory_freebsd.go
@@ -62,7 +62,7 @@ func collectMemoryStats() (*Stats, error) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// collect swap statistics from swapinfo command

--- a/memory/memory_freebsd.go
+++ b/memory/memory_freebsd.go
@@ -72,7 +72,7 @@ func collectMemoryStats() (*Stats, error) {
 	memory.SwapTotal, memory.SwapUsed, err = collectSwapStats(out)
 	if err != nil {
 		cmd.Process.Kill() // The process may stuck on write to pipe if the pipe buffer in kernel is full.
-		cmd.Wait()
+		go cmd.Wait()
 		return nil, err
 	}
 	if err := cmd.Wait(); err != nil {

--- a/memory/memory_freebsd.go
+++ b/memory/memory_freebsd.go
@@ -71,6 +71,8 @@ func collectMemoryStats() (*Stats, error) {
 	}
 	memory.SwapTotal, memory.SwapUsed, err = collectSwapStats(out)
 	if err != nil {
+		cmd.Process.Kill() // The process may stuck on write to pipe if the pipe buffer in kernel is full.
+		cmd.Wait()
 		return nil, err
 	}
 	if err := cmd.Wait(); err != nil {

--- a/network/network_bsd.go
+++ b/network/network_bsd.go
@@ -4,17 +4,22 @@ package network
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Get network statistics
 func Get() ([]Stats, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	// Reference: man 1 netstat
-	cmd := exec.Command("netstat", "-bni")
+	cmd := exec.CommandContext(ctx, "netstat", "-bni")
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -24,7 +29,6 @@ func Get() ([]Stats, error) {
 	}
 	networks, err := collectNetworkStats(out)
 	if err != nil {
-		cmd.Process.Kill() // The process may stuck on write to pipe if the pipe buffer in kernel is full.
 		go cmd.Wait()
 		return nil, err
 	}

--- a/network/network_bsd.go
+++ b/network/network_bsd.go
@@ -15,7 +15,7 @@ import (
 
 // Get network statistics
 func Get() ([]Stats, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Reference: man 1 netstat

--- a/network/network_bsd.go
+++ b/network/network_bsd.go
@@ -25,7 +25,7 @@ func Get() ([]Stats, error) {
 	networks, err := collectNetworkStats(out)
 	if err != nil {
 		cmd.Process.Kill() // The process may stuck on write to pipe if the pipe buffer in kernel is full.
-		cmd.Wait()
+		go cmd.Wait()
 		return nil, err
 	}
 	if err := cmd.Wait(); err != nil {

--- a/network/network_bsd.go
+++ b/network/network_bsd.go
@@ -24,6 +24,8 @@ func Get() ([]Stats, error) {
 	}
 	networks, err := collectNetworkStats(out)
 	if err != nil {
+		cmd.Process.Kill() // The process may stuck on write to pipe if the pipe buffer in kernel is full.
+		cmd.Wait()
 		return nil, err
 	}
 	if err := cmd.Wait(); err != nil {


### PR DESCRIPTION
On macOS 10.15.x Catalina (or later?), to execute new process will failed if the executable file of current process was removed. Thus if mackerel-agent is installed by Homebrew, `brew upgrade` will cause above catastrophe.

In result, it can occur many zombie processes because the functions that collect metrics such as *collectMemoryStats*, *collectSwapStats* will return an error.