### PR TITLE
Upgrade environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,14 @@ on:
     branches:
     - master
   pull_request:
+env:
+  GO111MODULE: on
 jobs:
   test:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'macos-10.15', 'windows-2019']
-        go: ['1.14.x']
+        go: ['1.15.x', '1.14.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,13 @@ on:
 env:
   GO111MODULE: on
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.35
   test:
     strategy:
       matrix:
@@ -26,5 +33,5 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - run: |
-        make lint test
+        make test
         go run ./cmd/osstat

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,9 @@
 .PHONY: all
-all: clean lint test
+all: clean test
 
 .PHONY: test
 test:
 	go test -v ./...
-
-.PHONY: lint
-lint: testdeps
-	golint -set_exit_status ./...
-
-.PHONY: testdeps
-testdeps:
-	go install golang.org/x/lint/golint
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a library to get system metrics like cpu load and memory usage.
 The library is created for [mackerel-agent](https://github.com/mackerelio/mackerel-agent).
 
-[![GoDoc](https://godoc.org/github.com/mackerelio/go-osstat?status.svg)](https://godoc.org/github.com/mackerelio/go-osstat)
+[![GoDev](https://pkg.go.dev/badge/github.com/mackerelio/go-osstat)](https://pkg.go.dev/github.com/mackerelio/go-osstat)
 [![Build Status](https://github.com/mackerelio/go-osstat/workflows/Build/badge.svg)](https://github.com/mackerelio/go-osstat/workflows/Build/badge.svg)
 
 ## Example

--- a/cmd/osstat/main.go
+++ b/cmd/osstat/main.go
@@ -1,3 +1,9 @@
+// osstat shows os system metric statistics.
+//
+// Usage:
+//
+//	osstat
+//
 package main
 
 import (
@@ -6,9 +12,6 @@ import (
 )
 
 var name = "osstat"
-var version = "v0.0.0"
-var description = "show os system metric statistics"
-var author = ""
 
 func main() {
 	if errs := run(os.Args[1:], os.Stdout); errs != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mackerelio/go-osstat
 
 go 1.15
 
-require golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
+require golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/mackerelio/go-osstat
 
 go 1.15
 
-require (
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
-	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
-)
+require golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mackerelio/go-osstat
 
-go 1.14
+go 1.15
 
 require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -1,17 +1,2 @@
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,0 @@
-// +build tools
-
-package goosstat
-
-import (
-	_ "golang.org/x/lint/golint"
-)


### PR DESCRIPTION
* added Go 1.15 support
* switched golint to golangci-lint
* change URLs: godoc.org -> pkg.go.dev