### PR TITLE
uptime: include openbsd build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ func main() {
 |Darwin|o|o|△<sup>*1</sup>|o|o|x|
 |FreeBSD|o|o|x|o|o|x|
 |NetBSD|o|o|x|x|o|x|
+|OpenBSD|x|o|x|x|x|x|
 |Windows|x|o|x|o|x|x|
 
 *1: unavailable without cgo

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func main() {
 |Darwin|o|o|△<sup>*1</sup>|o|o|x|
 |FreeBSD|o|o|x|o|o|x|
 |NetBSD|o|o|x|x|o|x|
-|OpenBSD|x|o|x|x|x|x|
+|OpenBSD|o|o|x|x|x|x|
 |Windows|x|o|x|o|x|x|
 
 *1: unavailable without cgo

--- a/uptime/uptime_bsd.go
+++ b/uptime/uptime_bsd.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd netbsd
+// +build darwin freebsd netbsd openbsd
 
 package uptime
 


### PR DESCRIPTION
The `uptime` package works fine on OpenBSD. Some of the other ones might work as well, but I haven't looked into it.