### PR TITLE
Add test with Go 1.16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'macos-10.15', 'windows-2019']
-        go: ['1.15.x', '1.14.x']
+        go: ['1.16.x', '1.15.x', '1.14.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I kept Go 1.14 tests, since https://github.com/mackerelio/mackerel-agent still build with Go 1.14.