### PR TITLE
[darwin] parse page size in vm_stat output

### DIFF
--- a/memory/memory_darwin.go
+++ b/memory/memory_darwin.go
@@ -61,9 +61,8 @@ type Stats struct {
 }
 
 // References:
-//   - https://support.apple.com/en-us/HT201464#memory
-//   - https://developer.apple.com/library/content/documentation/Performance/Conceptual/ManagingMemoryStats/Articles/AboutMemoryStats.html
-//   - https://opensource.apple.com/source/system_cmds/system_cmds-790/vm_stat.tproj/
+//   - https://support.apple.com/guide/activity-monitor/view-memory-usage-actmntr1004/10.14/mac/11.0
+//   - https://opensource.apple.com/source/system_cmds/system_cmds-880.60.2/vm_stat.tproj/
 func collectMemoryStats(out io.Reader) (*Stats, error) {
 	scanner := bufio.NewScanner(out)
 	if !scanner.Scan() {


### PR DESCRIPTION
The `vm_stat` command outputs the page size along with the snapshot values, and I think it's better to use this value than using a fixed value as we currently do.

I looked into some (older and newer) versions of `vm_stat` and the format seems to be unchanged, so there should be no compatibility issue.

- https://opensource.apple.com/source/system_cmds/
- oldest: https://opensource.apple.com/source/system_cmds/system_cmds-175.2/vm_stat.tproj/vm_stat.c.auto.html
- newest: https://opensource.apple.com/source/system_cmds/system_cmds-880.60.2/vm_stat.tproj/vm_stat.c.auto.html

Also updated the references (one has been moved, and one is not found).